### PR TITLE
[fix]floatmemoを開いた状態でdiffviewを使うとエラーになる

### DIFF
--- a/lua/floatmemo/init.lua
+++ b/lua/floatmemo/init.lua
@@ -30,12 +30,18 @@ function M.open()
   local win_id = window.create(buf_id)
   state.set_window(win_id)
   
+  -- floatmemo 専用の autocommand グループを作成（重複登録を防ぐ）
+  vim.api.nvim_create_augroup("floatmemo", { clear = true })
+  
   -- ウィンドウが閉じられたら自動的にcloseを呼ぶ
-  local close_cmd = string.format(
-    "autocmd WinClosed <buffer=%d> lua require('floatmemo').close()",
-    buf_id
-  )
-  vim.cmd(close_cmd)
+  vim.api.nvim_create_autocmd("WinClosed", {
+    group = "floatmemo",
+    callback = function(args)
+      if tonumber(args.match) == win_id then
+        require("floatmemo").close()
+      end
+    end,
+  })
 end
 
 -- メモウィンドウを閉じてクリーンアップ

--- a/lua/floatmemo/state.lua
+++ b/lua/floatmemo/state.lua
@@ -26,7 +26,7 @@ end
 -- ウィンドウが現在開いているかどうかを確認
 function M.is_open()
   local win_id = state.window_id
-  return win_id and vim.api.nvim_win_is_valid(win_id) or false
+  return (win_id and vim.api.nvim_win_is_valid(win_id)) or false
 end
 
 -- 状態をリセット（ウィンドウ閉じる時に呼ぶ）


### PR DESCRIPTION
3つの改善：

  - Lua API を直接使用 → `vim.cmd()` で文字列を組立てない（安全）
  - ウィンドウIDで監視 → バッファに依存しない（diffview の干渉を受けない）
  - `augroup` を作成 → 重複登録を防止（別途改良ポイント）

おまけの修正

  `return (win_id and vim.api.nvim_win_is_valid(win_id)) or false`

括弧を追加して 演算子の優先順位を明確化 しました。（Lua の `and` / `or` の結合優先度を考慮）

close #8 
